### PR TITLE
Iterate bundles for filesize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ _Pvt_Extensions/
 ModelManifest.xml
 AssetStudioFBX/AssetStudioFBX.vcxproj
 *.vcxproj
+AssetStudioFBX/AssetStudioFBX.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 AssetStudioFBX/AssetStudioFBX.vcxproj
+*.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+AssetStudioFBX/AssetStudioFBX.vcxproj

--- a/AssetStudio/AssetStudio.csproj
+++ b/AssetStudio/AssetStudio.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AssetStudio</RootNamespace>
     <AssemblyName>AssetStudio</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/AssetStudioFBX/AssetStudioFBX.vcxproj
+++ b/AssetStudioFBX/AssetStudioFBX.vcxproj
@@ -21,37 +21,37 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{4F8EF5EF-732B-49CF-9EB3-B23E19AE6267}</ProjectGuid>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>AssetStudioFBX</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/AssetStudioGUI/AssetStudioGUI.csproj
+++ b/AssetStudioGUI/AssetStudioGUI.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AssetStudioGUI</RootNamespace>
     <AssemblyName>AssetStudioGUI</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/AssetStudioGUI/AssetStudioGUIForm.Designer.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.Designer.cs
@@ -37,7 +37,9 @@
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.extractFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.extractFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+			this.filesizeByTypeInFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.displayAll = new System.Windows.Forms.ToolStripMenuItem();
             this.displayOriginalName = new System.Windows.Forms.ToolStripMenuItem();
             this.enablePreview = new System.Windows.Forms.ToolStripMenuItem();
@@ -157,7 +159,10 @@
             this.loadFolderToolStripMenuItem,
             this.toolStripMenuItem1,
             this.extractFileToolStripMenuItem,
-            this.extractFolderToolStripMenuItem});
+            this.extractFolderToolStripMenuItem,
+			this.toolStripMenuItem2,
+			this.filesizeByTypeInFolderToolStripMenuItem
+			} );
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(39, 21);
             this.fileToolStripMenuItem.Text = "File";
@@ -194,10 +199,22 @@
             this.extractFolderToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
             this.extractFolderToolStripMenuItem.Text = "Extract folder";
             this.extractFolderToolStripMenuItem.Click += new System.EventHandler(this.extractFolderToolStripMenuItem_Click);
-            // 
-            // optionsToolStripMenuItem
-            // 
-            this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			//
+			// toolStripMenuItem2
+			//
+			this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+			this.toolStripMenuItem2.Size = new System.Drawing.Size( 151, 6 );
+			//
+			// filesizeByTypeInFolderToolStripMenuItem
+			//
+			this.filesizeByTypeInFolderToolStripMenuItem.Name = "filesizeByTypeInFolderToolStripMenuItem";
+			this.filesizeByTypeInFolderToolStripMenuItem.Size = new System.Drawing.Size( 154, 22 );
+			this.filesizeByTypeInFolderToolStripMenuItem.Text = "Filesize by Type in folder";
+			this.filesizeByTypeInFolderToolStripMenuItem.Click += new System.EventHandler( this.filesizeByTypeInFolderToolStripMenuItem_Click );
+			// 
+			// optionsToolStripMenuItem
+			// 
+			this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.displayAll,
             this.displayOriginalName,
             this.enablePreview,
@@ -1058,7 +1075,9 @@
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem extractFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem extractFolderToolStripMenuItem;
-        private System.Windows.Forms.OpenFileDialog openFileDialog1;
+		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
+		private System.Windows.Forms.ToolStripMenuItem filesizeByTypeInFolderToolStripMenuItem;
+		private System.Windows.Forms.OpenFileDialog openFileDialog1;
         private System.Windows.Forms.SaveFileDialog saveFileDialog1;
         private System.Windows.Forms.ToolStripComboBox assetGroupOptions;
         private System.Windows.Forms.ToolStripMenuItem openAfterExport;

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -123,8 +123,17 @@ namespace AssetStudioGUI
             var openFolderDialog1 = new OpenFolderDialog();
             if (openFolderDialog1.ShowDialog(this) == DialogResult.OK)
             {
+				// Clear file stats
+
                 var files = Directory.GetFiles(openFolderDialog1.Folder, "*.*", SearchOption.AllDirectories);
-                ExtractFile(files);
+				foreach(var file in files)
+				{
+					if ( file.Contains( ".manifest" ) ) continue;
+
+					// Get stats for this file
+				}
+
+				// Print file stats
             }
         }
 
@@ -133,8 +142,9 @@ namespace AssetStudioGUI
 			var openFolderDialog = new OpenFolderDialog();
 			if (openFolderDialog.ShowDialog(this) == DialogResult.OK)
 			{
-				var files = Directory.GetFiles( openFolderDialog.Folder, "" );
-				Debug.Write( string.Format( "Found {0} bundles", files.Length ) );
+				var files = Directory.GetFiles( openFolderDialog.Folder, "*.*", SearchOption.AllDirectories );
+
+				Debug.Write( string.Format( "Found {0} files", files.Length ) );
 			}
 		}
 

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Windows.Forms;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
@@ -137,47 +138,82 @@ namespace AssetStudioGUI
 				Studio.sizeByAssetType.Clear();
 
 				var files = Directory.GetFiles( openFolderDialog1.Folder, "*.*", SearchOption.AllDirectories );
-				foreach ( var file in files )
-				{
-					if ( file.Contains( ".manifest" ) ) continue;
-
-					// Get stats for this file
-					ResetForm();
-					ThreadPool.QueueUserWorkItem( state =>
-					{
-						assetsManager.LoadFiles( openFileDialog1.FileNames );
-						BuildAssetStructures();
-					} );
-
-				}
-
-				// Print file stats
-				List<string> types = new List<string>( Studio.sizeByAssetType.Keys );
-				List<long> sizes = new List<long>( Studio.sizeByAssetType.Values );
-
-				// Insertion sort both at once by size
-				int i = 1;
-				while ( i < sizes.Count )
-				{
-					int j = i;
-					while ( j > 0 && sizes[ j - 1 ] > sizes[ j ] )
-					{
-						Swap( types, j, j - 1 );
-						Swap( sizes, j, j - 1 );
-						j--;
-					}
-				}
-
-				string str = "";
-				long totalSize = 0;
-				for ( int j = 0; j < sizes.Count; j++ )
-				{
-					str += types[ j ] + ": " + sizes[ j ] + "\n";
-					totalSize += sizes[ j ];
-				}
-				str += "Total Size: " + totalSize;
-				Console.Write( str );
+				ProcessFiles( files );
 			}
+		}
+
+		// Must control program flow so that only one asset processes at a time, and wait till all are processed
+		// One at a time
+		//Semaphore oneBundleSemaphore;
+		// All must finish
+		//CountdownEvent allBundlesCountdown;
+
+		async Task ProcessFiles( string[] files )
+		{
+
+			List<string> toProcessFiles = new List<string>();
+			foreach ( var file in files )
+			{
+				if ( file.Contains( ".manifest" ) == false )
+					toProcessFiles.Add( file );
+			}
+
+			//allBundlesCountdown = new CountdownEvent( toProcessFiles.Count );
+			//oneBundleSemaphore = new Semaphore( 1, 1 );
+			foreach ( var file in toProcessFiles )
+			{
+				await ProcessFile( file );
+			}
+
+			// Wait for all bundles
+			//allBundlesCountdown.Wait();
+
+			// Print file stats
+			List<string> types = new List<string>( Studio.sizeByAssetType.Keys );
+			List<long> sizes = new List<long>( Studio.sizeByAssetType.Values );
+
+			// Insertion sort both at once by size
+			int i = 1;
+			while ( i < sizes.Count )
+			{
+				int j = i;
+				while ( j > 0 && sizes[ j - 1 ] > sizes[ j ] )
+				{
+					Swap( types, j, j - 1 );
+					Swap( sizes, j, j - 1 );
+					j--;
+				}
+			}
+
+			string str = "";
+			long totalSize = 0;
+			for ( int j = 0; j < sizes.Count; j++ )
+			{
+				str += types[ j ] + ": " + sizes[ j ] + "\n";
+				totalSize += sizes[ j ];
+			}
+			str += "Total Size: " + totalSize;
+			Debug.WriteLine( str );
+		}
+
+		async Task ProcessFile ( string file )
+		{
+
+			// Get stats for this file
+			ResetForm();
+
+			//ThreadPool.QueueUserWorkItem( state =>
+			{
+				// Each worker thread begins by requesting the
+				// semaphore.
+				Console.WriteLine( "Thread '{0}' queues.", file );
+				//oneBundleSemaphore.WaitOne();
+				//Console.WriteLine( "Thread '{0}' enters the semaphore.", file );
+
+				assetsManager.LoadFiles( new string[] { file } );
+				await BuildAssetStructures();
+			}
+			//);
 		}
 		void Swap<T>( List<T> list, int a, int b )
 		{
@@ -186,7 +222,8 @@ namespace AssetStudioGUI
 			list[ b ] = tmp;
 		}
 
-		private void BuildAssetStructures()
+		
+		async Task BuildAssetStructures()
         {
             if (assetsManager.assetsFileList.Count == 0)
             {
@@ -214,68 +251,86 @@ namespace AssetStudioGUI
                 typeMap = BuildClassStructure();
             }
 
-            BeginInvoke(new Action(() =>
-            {
-                if (!string.IsNullOrEmpty(productName))
-                {
-                    Text = $"AssetStudioGUI - {productName} - {assetsManager.assetsFileList[0].unityVersion} - {assetsManager.assetsFileList[0].m_TargetPlatform}";
-                }
-                else
-                {
-                    Text = $"AssetStudioGUI - no productName - {assetsManager.assetsFileList[0].unityVersion} - {assetsManager.assetsFileList[0].m_TargetPlatform}";
-                }
-                if (!dontLoadAssetsMenuItem.Checked)
-                {
-                    assetListView.VirtualListSize = visibleAssets.Count;
-                    resizeAssetListColumns();
-                }
-                if (!dontBuildHierarchyMenuItem.Checked)
-                {
-                    sceneTreeView.BeginUpdate();
-                    sceneTreeView.Nodes.AddRange(treeNodeCollection.ToArray());
-                    treeNodeCollection.Clear();
-                    foreach (TreeNode node in sceneTreeView.Nodes)
-                    {
-                        node.HideCheckBox();
-                    }
-                    sceneTreeView.EndUpdate();
-                }
-                if (buildClassStructuresMenuItem.Checked)
-                {
-                    classesListView.BeginUpdate();
-                    foreach (var version in typeMap)
-                    {
-                        var versionGroup = new ListViewGroup(version.Key);
-                        classesListView.Groups.Add(versionGroup);
+			
+			IAsyncResult async = BeginInvoke( new Action( () =>
+			{
+				if ( !string.IsNullOrEmpty( productName ) )
+				{
+					Text = $"AssetStudioGUI - {productName} - {assetsManager.assetsFileList[ 0 ].unityVersion} - {assetsManager.assetsFileList[ 0 ].m_TargetPlatform}";
+				}
+				else
+				{
+					Text = $"AssetStudioGUI - no productName - {assetsManager.assetsFileList[ 0 ].unityVersion} - {assetsManager.assetsFileList[ 0 ].m_TargetPlatform}";
+				}
+				if ( !dontLoadAssetsMenuItem.Checked )
+				{
+					assetListView.VirtualListSize = visibleAssets.Count;
+					resizeAssetListColumns();
+				}
+				if ( !dontBuildHierarchyMenuItem.Checked )
+				{
+					sceneTreeView.BeginUpdate();
+					sceneTreeView.Nodes.AddRange( treeNodeCollection.ToArray() );
+					treeNodeCollection.Clear();
+					foreach ( TreeNode node in sceneTreeView.Nodes )
+					{
+						node.HideCheckBox();
+					}
+					sceneTreeView.EndUpdate();
+				}
+				if ( buildClassStructuresMenuItem.Checked )
+				{
+					classesListView.BeginUpdate();
+					foreach ( var version in typeMap )
+					{
+						var versionGroup = new ListViewGroup( version.Key );
+						classesListView.Groups.Add( versionGroup );
 
-                        foreach (var uclass in version.Value)
-                        {
-                            uclass.Value.Group = versionGroup;
-                            classesListView.Items.Add(uclass.Value);
-                        }
-                    }
-                    typeMap.Clear();
-                    classesListView.EndUpdate();
-                }
+						foreach ( var uclass in version.Value )
+						{
+							uclass.Value.Group = versionGroup;
+							classesListView.Items.Add( uclass.Value );
+						}
+					}
+					typeMap.Clear();
+					classesListView.EndUpdate();
+				}
 
-                var types = exportableAssets.Select(x => x.Type).Distinct().OrderBy(x => x.ToString()).ToArray();
-                foreach (var type in types)
-                {
-                    var typeItem = new ToolStripMenuItem
-                    {
-                        CheckOnClick = true,
-                        Name = type.ToString(),
-                        Size = new Size(180, 22),
-                        Text = type.ToString()
-                    };
-                    typeItem.Click += typeToolStripMenuItem_Click;
-                    filterTypeToolStripMenuItem.DropDownItems.Add(typeItem);
-                }
-                allToolStripMenuItem.Checked = true;
-                StatusStripUpdate($"Finished loading {assetsManager.assetsFileList.Count} files with {assetListView.Items.Count} exportable assets.");
-                treeSearch.Select();
-            }));
-        }
+				var types = exportableAssets.Select( x => x.Type ).Distinct().OrderBy( x => x.ToString() ).ToArray();
+				foreach ( var type in types )
+				{
+					var typeItem = new ToolStripMenuItem
+					{
+						CheckOnClick = true,
+						Name = type.ToString(),
+						Size = new Size( 180, 22 ),
+						Text = type.ToString()
+					};
+					typeItem.Click += typeToolStripMenuItem_Click;
+					filterTypeToolStripMenuItem.DropDownItems.Add( typeItem );
+				}
+				allToolStripMenuItem.Checked = true;
+				StatusStripUpdate( $"Finished loading {assetsManager.assetsFileList.Count} files with {assetListView.Items.Count} exportable assets." );
+				treeSearch.Select();
+				
+			Debug.Write( "Task has finished\n" );
+			} ) );
+
+
+			await Task.Factory.FromAsync( async, Complete );
+		}
+		void Complete( IAsyncResult result )
+		{
+			// All done
+			// Decrement semaphore and countdown
+			//if ( oneBundleSemaphore != null )
+			{
+				//oneBundleSemaphore.Release();
+			}
+			//if ( allBundlesCountdown != null )
+			//	allBundlesCountdown.Signal();
+		}
+
 
         private void typeToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -128,6 +128,16 @@ namespace AssetStudioGUI
             }
         }
 
+		private void filesizeByTypeInFolderToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			var openFolderDialog = new OpenFolderDialog();
+			if (openFolderDialog.ShowDialog(this) == DialogResult.OK)
+			{
+				var files = Directory.GetFiles( openFolderDialog.Folder, "" );
+				Debug.Write( string.Format( "Found {0} bundles", files.Length ) );
+			}
+		}
+
         private void BuildAssetStructures()
         {
             if (assetsManager.assetsFileList.Count == 0)

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -134,8 +134,30 @@ namespace AssetStudioGUI
 				}
 
 				// Print file stats
+				Dictionary<string, long> types = new Dictionary<string, long>();
+				List<string> typesList = new List<string>( types.Keys );
+				List<long> sizeList = new List<long>( types.Values );
+
+				// Insertion sort both at once by size
+				int i = 1;
+				while( i < sizeList.Count )
+				{
+					int j = i;
+					while ( j > 0 && sizeList[j-1] > sizeList[ j ] )
+					{
+						Swap( typesList, j, j - 1 );
+						Swap( sizeList, j, j - 1 );
+						j--;
+					}
+				}
             }
         }
+		void Swap<T>( List<T> list, int a, int b )
+		{
+			T tmp = list[a];
+			list[ a ] = list[ b ];
+			list[ b ] = tmp;
+		}
 
 		private void filesizeByTypeInFolderToolStripMenuItem_Click(object sender, EventArgs e)
 		{

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -136,6 +136,7 @@ namespace AssetStudioGUI
 			{
 				// Clear file stats
 				Studio.sizeByAssetType.Clear();
+                Studio.objectNames.Clear();
 
 				var files = Directory.GetFiles( openFolderDialog1.Folder, "*.*", SearchOption.AllDirectories );
 				ProcessFiles( files );
@@ -183,6 +184,7 @@ namespace AssetStudioGUI
 					Swap( sizes, j, j - 1 );
 					j--;
 				}
+                i++;
 			}
 
 			string str = "";

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -120,26 +120,36 @@ namespace AssetStudioGUI
 
         private void extractFolderToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var openFolderDialog1 = new OpenFolderDialog();
-            if (openFolderDialog1.ShowDialog(this) == DialogResult.OK)
-            {
-                // Clear file stats
-                Studio.sizeByAssetType.Clear();
+			var openFolderDialog1 = new OpenFolderDialog();
+			if ( openFolderDialog1.ShowDialog( this ) == DialogResult.OK )
+			{
+				var files = Directory.GetFiles( openFolderDialog1.Folder, "*.*", SearchOption.AllDirectories );
+				ExtractFile( files );
+			}
+		}
 
-                var files = Directory.GetFiles(openFolderDialog1.Folder, "*.*", SearchOption.AllDirectories);
-				foreach(var file in files)
+		private void filesizeByTypeInFolderToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			var openFolderDialog1 = new OpenFolderDialog();
+			if ( openFolderDialog1.ShowDialog( this ) == DialogResult.OK )
+			{
+				// Clear file stats
+				Studio.sizeByAssetType.Clear();
+
+				var files = Directory.GetFiles( openFolderDialog1.Folder, "*.*", SearchOption.AllDirectories );
+				foreach ( var file in files )
 				{
 					if ( file.Contains( ".manifest" ) ) continue;
 
-                    // Get stats for this file
-                    ResetForm();
-                    ThreadPool.QueueUserWorkItem(state =>
-                    {
-                        assetsManager.LoadFiles(openFileDialog1.FileNames);
-                        BuildAssetStructures();
-                    });
+					// Get stats for this file
+					ResetForm();
+					ThreadPool.QueueUserWorkItem( state =>
+					{
+						assetsManager.LoadFiles( openFileDialog1.FileNames );
+						BuildAssetStructures();
+					} );
 
-                }
+				}
 
 				// Print file stats
 				List<string> types = new List<string>( Studio.sizeByAssetType.Keys );
@@ -147,10 +157,10 @@ namespace AssetStudioGUI
 
 				// Insertion sort both at once by size
 				int i = 1;
-				while( i < sizes.Count )
+				while ( i < sizes.Count )
 				{
 					int j = i;
-					while ( j > 0 && sizes[j-1] > sizes[ j ] )
+					while ( j > 0 && sizes[ j - 1 ] > sizes[ j ] )
 					{
 						Swap( types, j, j - 1 );
 						Swap( sizes, j, j - 1 );
@@ -160,34 +170,23 @@ namespace AssetStudioGUI
 
 				string str = "";
 				long totalSize = 0;
-                for( int j=0; j<sizes.Count; j++ )
-                {
-                    str += types[j] + ": " + sizes[j] +"\n";
+				for ( int j = 0; j < sizes.Count; j++ )
+				{
+					str += types[ j ] + ": " + sizes[ j ] + "\n";
 					totalSize += sizes[ j ];
 				}
 				str += "Total Size: " + totalSize;
 				Console.Write( str );
-            }
-        }
+			}
+		}
 		void Swap<T>( List<T> list, int a, int b )
 		{
-			T tmp = list[a];
+			T tmp = list[ a ];
 			list[ a ] = list[ b ];
 			list[ b ] = tmp;
 		}
 
-		private void filesizeByTypeInFolderToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			var openFolderDialog = new OpenFolderDialog();
-			if (openFolderDialog.ShowDialog(this) == DialogResult.OK)
-			{
-				var files = Directory.GetFiles( openFolderDialog.Folder, "*.*", SearchOption.AllDirectories );
-
-				Debug.Write( string.Format( "Found {0} files", files.Length ) );
-			}
-		}
-
-        private void BuildAssetStructures()
+		private void BuildAssetStructures()
         {
             if (assetsManager.assetsFileList.Count == 0)
             {

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -123,17 +123,31 @@ namespace AssetStudioGUI
             var openFolderDialog1 = new OpenFolderDialog();
             if (openFolderDialog1.ShowDialog(this) == DialogResult.OK)
             {
-				// Clear file stats
+                // Clear file stats
+                Studio.sizeByAssetType.Clear();
 
                 var files = Directory.GetFiles(openFolderDialog1.Folder, "*.*", SearchOption.AllDirectories);
 				foreach(var file in files)
 				{
 					if ( file.Contains( ".manifest" ) ) continue;
 
-					// Get stats for this file
-				}
+                    // Get stats for this file
+                    ResetForm();
+                    ThreadPool.QueueUserWorkItem(state =>
+                    {
+                        assetsManager.LoadFiles(openFileDialog1.FileNames);
+                        BuildAssetStructures();
+                    });
+
+                }
 
 				// Print file stats
+                foreach(string s in Studio.sizeByAssetType.Keys)
+                {
+                    Console.WriteLine(s + ": " + Studio.sizeByAssetType[s]);
+                }
+
+
             }
         }
 

--- a/AssetStudioGUI/Studio.cs
+++ b/AssetStudioGUI/Studio.cs
@@ -18,6 +18,8 @@ namespace AssetStudioGUI
         public static ScriptDumper scriptDumper = new ScriptDumper();
         public static List<AssetItem> exportableAssets = new List<AssetItem>();
         public static List<AssetItem> visibleAssets = new List<AssetItem>();
+        public static HashSet<string> objectNames = new HashSet<string>();
+
 
         public static Dictionary<string, long> sizeByAssetType = new Dictionary<string, long>();
 
@@ -208,14 +210,21 @@ namespace AssetStudioGUI
                         tempExportableAssets.Add(assetItem);
                     }
 
+
+
                     //Add to dictionary
-                    if(sizeByAssetType.ContainsKey(assetItem.TypeString))
+                    string obj = assetItem.Text + "_" + assetItem.TypeString;
+                    if (!objectNames.Contains(obj))
                     {
-                        sizeByAssetType[assetItem.TypeString] += assetItem.FullSize;
-                    }
-                    else
-                    {
-                        sizeByAssetType.Add(assetItem.TypeString, assetItem.FullSize);
+                        objectNames.Add(obj);
+                        if (sizeByAssetType.ContainsKey(assetItem.TypeString))
+                        {
+                            sizeByAssetType[assetItem.TypeString] += assetItem.FullSize;
+                        }
+                        else
+                        {
+                            sizeByAssetType.Add(assetItem.TypeString, assetItem.FullSize);
+                        }
                     }
 
                     Progress.Report(++j, progressCount);
@@ -365,7 +374,9 @@ namespace AssetStudioGUI
 
         public static string FixFileName(string str)
         {
-            if (str.Length >= 260) return Path.GetRandomFileName();
+            //if (str.Length >= 260) return Path.GetRandomFileName();
+
+            if (str.Length >= 260) return str.Substring(0, 255);
             return Path.GetInvalidFileNameChars().Aggregate(str, (current, c) => current.Replace(c, '_'));
         }
 

--- a/AssetStudioGUI/Studio.cs
+++ b/AssetStudioGUI/Studio.cs
@@ -19,6 +19,9 @@ namespace AssetStudioGUI
         public static List<AssetItem> exportableAssets = new List<AssetItem>();
         public static List<AssetItem> visibleAssets = new List<AssetItem>();
 
+        public static Dictionary<string, long> sizeByAssetType = new Dictionary<string, long>();
+
+
         public static void ExtractFile(string[] fileNames)
         {
             ThreadPool.QueueUserWorkItem(state =>
@@ -205,6 +208,16 @@ namespace AssetStudioGUI
                         tempExportableAssets.Add(assetItem);
                     }
 
+                    //Add to dictionary
+                    if(sizeByAssetType.ContainsKey(assetItem.TypeString))
+                    {
+                        sizeByAssetType[assetItem.TypeString] += assetItem.FullSize;
+                    }
+                    else
+                    {
+                        sizeByAssetType.Add(assetItem.TypeString, assetItem.FullSize);
+                    }
+
                     Progress.Report(++j, progressCount);
                 }
                 if (displayOriginalName && ab != null)
@@ -233,6 +246,7 @@ namespace AssetStudioGUI
             }
 
             visibleAssets = exportableAssets;
+
             assetsNameHash.Clear();
         }
 

--- a/AssetStudioUtility/AssetStudioUtility.csproj
+++ b/AssetStudioUtility/AssetStudioUtility.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AssetStudio</RootNamespace>
     <AssemblyName>AssetStudioUtility</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Added new menu option "File->Filesize by Type in folder" that creates a debug log of compressed filesizes by type for all asset bundles in a folder.
Upgraded .NET from 4.0 to 4.5 for "await"